### PR TITLE
Fix landing page comments and week links

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 
 <html lang="en">
 <head>
-       HEAD SECTION
+<!--        HEAD SECTION
        Contains meta information, the page title, and internal CSS styles.
   ============================================================ -->
 <meta charset="utf-8"/>
@@ -12,14 +12,14 @@
 <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
-       HEADER SECTION
+<!--        HEADER SECTION
        Contains the website title and tagline.
   ============================================================ -->
 <header>
 <h1>Year 10 Industrial Technology Timber - 2025</h1>
 <p>Resources, Projects, and Content for Learning</p>
 </header>
-       GOOGLE CLASSROOM SECTION
+<!--        GOOGLE CLASSROOM SECTION
        Contains the invitation and link to join Google Classroom.
   ============================================================ -->
 <section aria-label="Google Classroom Invitation" class="google-classroom">
@@ -31,7 +31,7 @@
 <p><strong>Classroom Code: <span style="color: #d9534f; font-size: 1.3em;">l3uugkr</span></strong></p>
 <a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" target="_blank">Join Google Classroom</a>
 </section>
-       NAVIGATION SECTION
+<!--        NAVIGATION SECTION
        Contains links to the different sections of the website.
   ============================================================ -->
 <nav aria-label="Main Navigation">
@@ -43,7 +43,7 @@
 <a class="nav-link" data-section="support-activities" href="#support-activities">Support Theory Content (Optional)</a>
 <a class="nav-link" data-section="advanced-activities" href="#advanced-activities">Advanced Theory Content (Optional)</a>
 </nav>
-       MAIN CONTENT SECTION
+<!--        MAIN CONTENT SECTION
        Contains the main content areas of the website.
   ============================================================ -->
 <main class="content">
@@ -665,7 +665,6 @@
 <p>This section compiles the theoretical background for each project. Detailed explanations, diagrams, and resource links are provided to support your learning.</p>
 <h3>Mirror Theory</h3>
 <p>The following detailed articles cover the Mirror unit, presented week-by-week to ensure you have a comprehensive understanding of the concepts, safety practices, and techniques required for success.</p>
-<!-- -------------------------
 <ul>
 <li><a href="weeks/week01.html">Week 1: Introduction, Workshop Safety &amp; Constraints</a></li>
 <li><a href="weeks/week02.html">Week 2: Design &amp; Sketches, Measuring &amp; Marking Out</a></li>
@@ -688,10 +687,7 @@
 <li><a href="weeks/week19.html">Week 19: Project Catch-Up &amp; Workshop Clean-Up</a></li>
 <li><a href="weeks/week20.html">Week 20: Project Hand-In &amp; Final Wrap-Up</a></li>
 </ul>
-         Support Theory Content Section
-         Optional simplified theory with quizzes.
-    -------------------------- -->
-<section class="content-section" id="support-activities" tabindex="0">
+<!-- Support Theory Content Section: Optional simplified theory with quizzes. -->
 <h2>Support Theory Content (Optional)</h2>
 <details>
 <summary><strong>Weeks 1 &amp; 2:</strong> Workshop Safety and Timber Marking</summary>
@@ -1495,7 +1491,7 @@
 </fieldset>
 <span class="quiz-msg"></span></form></article>
 </section>
-       FOOTER SECTION
+<!--        FOOTER SECTION
        Contains the footer content and back-to-top link.
   ============================================================ -->
 <footer>


### PR DESCRIPTION
## Summary
- comment out descriptive section labels so they don't appear on the page
- expose weekly theory links
- keep support theory heading notes as a comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871f7f74b3c83269658cdf3cfcd5c40