### PR TITLE
Support text answers in quizzes

### DIFF
--- a/apps-script.js
+++ b/apps-script.js
@@ -1,0 +1,20 @@
+/**
+ * Google Apps Script backend for quiz submissions.
+ * Records standard quiz scores and advanced theory responses.
+ */
+function doPost(e) {
+  var data = JSON.parse(e.postData.contents);
+  var ss = SpreadsheetApp.openById('SPREADSHEET_ID'); // TODO: replace with real ID
+  var mainSheet = ss.getSheetByName('Main Theory Sheet');
+  var advancedSheet = ss.getSheetByName('Advanced Theory Sheet');
+  var dateStr = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+
+  if (data.level === 'advanced' && Array.isArray(data.responses)) {
+    var answers = data.responses.map(function(r) { return r.answer; });
+    advancedSheet.appendRow([data.studentName, data.week, dateStr].concat(answers));
+  } else {
+    mainSheet.appendRow([data.studentName, data.week, data.score, dateStr]);
+  }
+
+  return ContentService.createTextOutput('success');
+}

--- a/script.js
+++ b/script.js
@@ -104,20 +104,30 @@ async function submitQuiz(button, week, level) {
   }
 
   const quizElement = button.closest('.quiz');
-  const answers = Array.from(quizElement.querySelectorAll('li')).map((li, index) => {
-    const questionText = li.querySelector('p').innerText;
+  const answers = [];
+  const responses = [];
+
+  Array.from(quizElement.querySelectorAll('li')).forEach((li, index) => {
+    const questionText = li.querySelector('p') ? li.querySelector('p').innerText : '';
+    const textarea = li.querySelector('textarea');
+
+    if (textarea) {
+      responses.push({ answer: textarea.value });
+      return;
+    }
+
     const selectedOption = li.querySelector('input[type="radio"]:checked');
     const correctOption = li.querySelector('input[data-correct="true"]');
 
     const isCorrect = selectedOption ? selectedOption.hasAttribute('data-correct') : false;
 
-    return {
+    answers.push({
       questionNumber: index + 1,
       questionText,
       studentAnswer: selectedOption ? selectedOption.value : 'No answer',
       correctAnswer: correctOption.value,
       isCorrect
-    };
+    });
   });
 
   const score = answers.filter(a => a.isCorrect).length;
@@ -130,6 +140,10 @@ async function submitQuiz(button, week, level) {
     level,
     score: scoreText
   };
+
+  if (responses.length > 0) {
+    payload.responses = responses;
+  }
 
   await fetch('https://script.google.com/macros/s/AKfycbya0EHlfInCNU8toTn0nNeHxJSIesb9V7ms4t1ZC7dflc9AJuraEHg4tS897fNNBsRm/exec', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- collect textarea responses when submitting quizzes
- include textarea answers in payload
- script for Apps Script backend to record advanced theory answers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68737957ee548326911b48308c5bb241